### PR TITLE
Explicitly use JavaVersion.VERSION_17 in core/build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,15 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
 }
 
 /*


### PR DESCRIPTION
I don't expect this to be needed because other moduels depend on :core:wallet-core and because other modules already use VERSION_17, but for some reason CI failed on the main branch after the submodule was added, and, empirically, this commit will probably fix it.