### PR TITLE
[WD-2584] Add batch issuance support for multiple credentials

### DIFF
--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/DefaultOpenId4VciManager.kt
@@ -183,7 +183,7 @@ internal class DefaultOpenId4VciManager(
     }
 
     override fun issueDocumentByConfigurationIdentifierAttested(
-        credentialConfigurationId: String,
+        credentialConfigurationIds: List<String>,
         walletAttestation: SignedJWT,
         walletWiaPopPublicKey: JWK,
         walletWiaPopPrivateKey: PrivateKey,
@@ -208,9 +208,9 @@ internal class DefaultOpenId4VciManager(
                 val issuer = issuerCreator.createIssuerWithAttestation(
                     attestationJWT = walletAttestation,
                     walletWiaPopSigner = walletWiaPopSigner,
-                    credentialConfigurationIdentifiers = listOf(
-                        CredentialConfigurationIdentifier(credentialConfigurationId)
-                    )
+                    credentialConfigurationIdentifiers = credentialConfigurationIds.map {
+                        CredentialConfigurationIdentifier(it)
+                    }
                 )
                 doIssue(issuer, Offer(issuer.credentialOffer), txCode, listener)
             } catch (e: Throwable) {
@@ -218,6 +218,27 @@ internal class DefaultOpenId4VciManager(
                 coroutineScope.cancel("issueDocumentByConfigurationIdentifierAttested failed", e)
             }
         }
+    }
+
+    @Deprecated("Use the List<String> version for batch issuance")
+    override fun issueDocumentByConfigurationIdentifierAttested(
+        credentialConfigurationId: String,
+        walletAttestation: SignedJWT,
+        walletWiaPopPublicKey: JWK,
+        walletWiaPopPrivateKey: PrivateKey,
+        txCode: String?,
+        executor: Executor?,
+        onIssueEvent: OpenId4VciManager.OnIssueEvent,
+    ) {
+        issueDocumentByConfigurationIdentifierAttested(
+            credentialConfigurationIds = listOf(credentialConfigurationId),
+            walletAttestation = walletAttestation,
+            walletWiaPopPublicKey = walletWiaPopPublicKey,
+            walletWiaPopPrivateKey = walletWiaPopPrivateKey,
+            txCode = txCode,
+            executor = executor,
+            onIssueEvent = onIssueEvent
+        )
     }
 
     override fun issueDocumentByFormat(

--- a/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManager.kt
+++ b/wallet-core/src/main/java/eu/europa/ec/eudi/wallet/issue/openid4vci/OpenId4VciManager.kt
@@ -91,6 +91,17 @@ interface OpenId4VciManager {
     )
 
     fun issueDocumentByConfigurationIdentifierAttested(
+        credentialConfigurationIds: List<String>,
+        walletAttestation: SignedJWT,
+        walletWiaPopPublicKey: JWK,
+        walletWiaPopPrivateKey: PrivateKey,
+        txCode: String? = null,
+        executor: Executor? = null,
+        onIssueEvent: OnIssueEvent,
+    )
+
+    @Deprecated("Use the List<String> version for batch issuance")
+    fun issueDocumentByConfigurationIdentifierAttested(
         credentialConfigurationId: String,
         walletAttestation: SignedJWT,
         walletWiaPopPublicKey: JWK,


### PR DESCRIPTION
Refactors `issueDocumentByConfigurationIdentifierAttested` to accept a `List<String>` of credential configuration identifiers, enabling simultaneous issuance of multiple documents (mdoc and sd-jwt) in a single request.